### PR TITLE
1.0.3. Fix for mandatory addition of webhook headers

### DIFF
--- a/action.php
+++ b/action.php
@@ -213,7 +213,10 @@ class action_plugin_discordnotifier extends DokuWiki_Action_Plugin
 
         // submit payload
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
-        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($this->_payload));
+		$json_payload = json_encode ( $this->_payload );
+		$payload_length = 'Content-length: ' . mb_strlen ( $json_payload );
+		curl_setopt ( $ch, CURLOPT_HTTPHEADER, array ( 'Content-type: application/json', $payload_length ) );
+        curl_setopt ( $ch, CURLOPT_POSTFIELDS, $json_payload );
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_exec($ch);
 


### PR DESCRIPTION
After 24/11 headers become mandatory in "Content-type: application/json; Content-length: X" format