### PR TITLE
Remove redundant helper->sendUpdate and ->shouldBeSent

### DIFF
--- a/action.php
+++ b/action.php
@@ -21,10 +21,11 @@ class action_plugin_discordnotifier extends DokuWiki_Action_Plugin {
 	}
 
 	function _handle ( Doku_Event $event, $param ) {
-	    /** @var helper_plugin_approve $helper */
-	    $helper = plugin_load('helper', 'discordnotifier');
+		/** @var helper_plugin_approve $helper */
+		$helper = plugin_load('helper', 'discordnotifier');
+
 		// filter writes to attic
-	    if ( $helper -> attic_write ( $event -> data['file'] ) ) return;
+		if ( $helper -> attic_write ( $event -> data['file'] ) ) return;
 
 		// filter namespace
 		if ( !$helper -> valid_namespace ( ) ) return;

--- a/helper.php
+++ b/helper.php
@@ -200,20 +200,4 @@ class helper_plugin_discordnotifier extends DokuWiki_Plugin {
         
     }
     
-    public function shouldBeSend($filename){
-        $send = true;
-        if($this -> attic_write ( $filename )) $send = false;
-        if(!$this -> valid_namespace ( )) $send = false;
-        return $send;
-    }
-
-    public function sendUpdate($event) {
-        
-        if(!($this->shouldBeSend($event -> data['file']) && !$this -> set_event ( $event ))) return ;
-        // set payload text
-        $this -> set_payload_text ( $event );
-        
-        // submit payload
-        $helper -> submit_payload ( );
-    }
 }


### PR DESCRIPTION
As Wilhelm wrote in issue #12, some code is duplicated between `action.php` and `helper.php`. I've removed `sendUpdate` and `shouldBeSent` from the helper class as they're not used anywhere.