### PR TITLE
Option to display either real names or username in notification

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -5,4 +5,5 @@ $conf['notify_edit'] = 1;
 $conf['notify_edit_minor'] = 1;
 $conf['notify_delete'] = 1;
 $conf['notify_show_summary'] = 1;
+$conf['notify_show_name'] = 'real name';
 $conf['webhook'] = "https://discordapp.com/api/webhooks/<id>/<token>";

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -5,4 +5,5 @@ $meta['notify_edit'] = array('onoff');
 $meta['notify_edit_minor'] = array('onoff');
 $meta['notify_delete'] = array('onoff');
 $meta['notify_show_summary'] = array('onoff');
+$meta['notify_show_name'] = array('multichoice', '_choices' => array('real name','username') );
 $meta['webhook'] = array('string');

--- a/helper.php
+++ b/helper.php
@@ -98,7 +98,13 @@ class helper_plugin_discordnotifier extends DokuWiki_Plugin {
                 break;
         }
         
-        $user = $INFO['userinfo']['name'];
+	if ( $this -> getConf ( 'notify_show_name' ) === 'real name' ) {
+		$user = $INFO['userinfo']['name'];
+	} elseif ( $this -> getConf ( 'notify_show_name' ) === 'username' ) {
+		$user = $_SERVER['REMOTE_USER'];
+	} else {
+		throw new Exception('invalid notify_show_name value');
+	}
         $link = $this -> _get_url ( $event, null );
         $page = $event -> data['id'];
         $description = "{$user} {$event_name} [__{$page}__]({$link})";

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -16,4 +16,5 @@ $lang['notify_edit'] = "Notify when pages are edited";
 $lang['notify_edit_minor'] = "Notify when pages are edited even with minor changes tag";
 $lang['notify_delete'] = "Notify when pages are deleted";
 $lang['notify_show_summary'] = "Display summary when a page is edited";
+$lang['notify_show_name'] = "Name to display in notification";
 $lang['webhook'] = "Discord Incoming Webhook URL";


### PR DESCRIPTION
Added an admin config option to choose whether to display the real name or username in notifications (#14). Defaults to real name.