### PR TITLE
PHP8.1 fix - helper.php

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -110,8 +110,8 @@ class helper_plugin_discordnotifier extends DokuWiki_Plugin {
         $description = "{$user} {$event_name} [__{$page}__]({$link})";
         
         if ( $this -> _event != 'delete' ) {
-            $oldRev = $INFO['meta']['last_change']['date'];
-            if ( !empty ( $oldRev ) ) {
+            if ( isset ( $INFO['meta']['last_change'] ) ) {
+                $oldRev = $INFO['meta']['last_change']['date'];
                 $diffURL = $this -> _get_url ( $event, $oldRev );
                 $description .= " \([" . $this -> getLang ( 'compare' ) . "]({$diffURL})\)";
             }


### PR DESCRIPTION
This fixes the `E_WARNING: Undefined array key "last_change"` warning on PHP 8.1