### PR TITLE
feat: Modernize DokuWiki Discord Notifier Plugin

### DIFF
--- a/action.php
+++ b/action.php
@@ -6,14 +6,6 @@
  *
  */
 
-if ( !defined ( 'DOKU_INC' ) ) die ( );
-
-//require_once ( DOKU_INC.'inc/changelog.php' );
-
-if ( !defined ( 'DOKU_LF' ) ) define ( 'DOKU_LF', "\n" );
-if ( !defined ( 'DOKU_TAB' ) ) define ( 'DOKU_TAB', "\t" );
-if ( !defined ( 'DOKU_PLUGIN' ) ) define ( 'DOKU_PLUGIN', DOKU_INC . 'lib/plugins/' );
-
 class action_plugin_discordnotifier extends DokuWiki_Action_Plugin {
 
 	function register ( Doku_Event_Handler $controller ) {

--- a/helper.php
+++ b/helper.php
@@ -1,7 +1,5 @@
 <?php
 
-// must be run within Dokuwiki
-if (!defined('DOKU_INC')) die();
 class helper_plugin_discordnotifier extends DokuWiki_Plugin {
     
     var $_event = null;
@@ -101,7 +99,8 @@ class helper_plugin_discordnotifier extends DokuWiki_Plugin {
 	if ( $this -> getConf ( 'notify_show_name' ) === 'real name' ) {
 		$user = $INFO['userinfo']['name'];
 	} elseif ( $this -> getConf ( 'notify_show_name' ) === 'username' ) {
-		$user = $_SERVER['REMOTE_USER'];
+		global $INPUT;
+		$user = $INPUT->server->str('REMOTE_USER');
 	} else {
 		throw new Exception('invalid notify_show_name value');
 	}


### PR DESCRIPTION
This commit introduces several modernizations to the DokuWiki Discord Notifier plugin:

Removed obsolete DOKU_INC definition check in helper.php to align with modern DokuWiki loading mechanisms. Replaced $_SERVER['REMOTE_USER'] with $INPUT->server->str('REMOTE_USER') in helper.php for safer and type-aware access to server variables, adhering to DokuWiki's $INPUT global object best practices. These changes ensure better compatibility with DokuWiki 2025-05-14a "Librarian" and improve adherence to modern PHP development standards.